### PR TITLE
Fixes finding plugins when running directly from the .exe

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -27,15 +27,16 @@ use crate::state::{State, UserSettings};
 use crate::term::TerminalBackend;
 use std::sync::Arc;
 
-fn find_repo_root() -> Option<std::path::PathBuf> {
-    if let Ok(exe_path) = std::env::current_exe() {
-        let mut current = exe_path.parent()?;
-        for _ in 0..10 {
-            if current.join("Cargo.toml").exists() {
-                return Some(current.to_path_buf());
-            }
-            current = current.parent()?;
+// Looks for runtime/plugins directory when running rift from rift.exe
+fn find_runtime_plugins() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let mut dir = exe.parent()?;   
+    for _ in 0..10 {
+        let candidate = dir.join("runtime").join("plugins");
+        if candidate.is_dir() {
+            return Some(candidate);
         }
+        dir = dir.parent()?;
     }
     None
 }
@@ -44,8 +45,8 @@ fn plugin_dirs() -> Vec<std::path::PathBuf> {
     let mut dirs = Vec::new();
     if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
         dirs.push(std::path::PathBuf::from(manifest).join("runtime").join("plugins"));
-    } else if let Some(repo_root) = find_repo_root() {
-        dirs.push(repo_root.join("runtime").join("plugins"));
+    } else if let Some(path) = find_runtime_plugins() {
+        dirs.push(path);
     }
     let user_dir = if cfg!(windows) {
         std::env::var("APPDATA").ok().map(|d| {


### PR DESCRIPTION
* **Can now use :reload when running from .exe**
* **Fixes confirming in rift folder**


Can test by running :reload with plugins in the runtime/plugins folder in the rift project directory.
Also works in %APPDATA%/rift/plugins

